### PR TITLE
change index for PWDB & EurLex

### DIFF
--- a/resources/elasticsearch/eurlex_extended_index_mapping.json
+++ b/resources/elasticsearch/eurlex_extended_index_mapping.json
@@ -181,7 +181,7 @@
       },
       "content": {
         "type": "text",
-        "analyzer": "standard"
+        "analyzer": "english"
       }
     }
   }

--- a/resources/elasticsearch/eurlex_index_mapping.json
+++ b/resources/elasticsearch/eurlex_index_mapping.json
@@ -181,7 +181,7 @@
       },
       "content": {
         "type": "text",
-        "analyzer": "standard"
+        "analyzer": "english"
       }
     }
   }

--- a/resources/elasticsearch/pwdb_index_mapping.json
+++ b/resources/elasticsearch/pwdb_index_mapping.json
@@ -64,7 +64,7 @@
       },
       "creation_date": {
         "type": "date",
-        "format": "dd/MM/YYYY"
+        "format": "MM/dd/YYYY"
       },
       "date_type": {
         "type": "text",
@@ -77,7 +77,7 @@
       },
       "end_date": {
         "type": "date",
-        "format": "dd/MM/YYYY"
+        "format": "MM/dd/YYYY"
       },
       "actors": {
         "type": "text",
@@ -134,7 +134,7 @@
       },
       "start_date": {
         "type": "date",
-        "format": "dd/MM/YYYY"
+        "format": "MM/dd/YYYY"
       },
       "status_of_regulation": {
         "type": "text",


### PR DESCRIPTION
   1. [PWDB] Date format is not correctly mapped in elastic search.

  2.  [EurLex] change the content analyser from “standard“ to “english“.